### PR TITLE
Implement Person card component and responsive grid

### DIFF
--- a/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
+++ b/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
@@ -213,6 +213,12 @@ class StyleGuideController extends ControllerBase {
     $element = $this->getWebformElement();
     $build[] = $this->wrapElementNoContainer($element, 'Element: Webform');
 
+    $element = $this->getPersonCard();
+    $build[] = $this->wrapElementWideContainer($element, 'Person card');
+
+    $element = $this->getPersonCardGrid();
+    $build[] = $this->wrapElementWideContainer($element, 'Person card grid');
+
     return $build;
   }
 
@@ -934,6 +940,154 @@ class StyleGuideController extends ControllerBase {
       $this->getRandomTitle(),
       $this->buildProcessedText('Decorate one package of cauliflower in six teaspoons of plain vinegar. Try flavoring the crême fraîche gingers with clammy rum and fish sauce, simmered.'),
     );
+  }
+
+  /**
+   * Get Person card element.
+   *
+   * @return array
+   *   Render array.
+   */
+  protected function getPersonCard(): array {
+    $people = [
+      [
+        'name' => 'Jon Doe',
+        'title' => 'General Director',
+        'role' => 'Admin',
+        'email' => 'jon.doe@example.com',
+        'phone' => '+1234567890',
+      ],
+      [
+        'name' => 'Smith Allen',
+        'title' => 'Assistant Manager',
+        'role' => 'Manager',
+        'email' => 'jon.doe@example.com',
+        'phone' => '+1234567890',
+      ],
+      [
+        'name' => 'David Bowie',
+        'title' => 'Lead Designer',
+        'role' => 'Designer',
+        'email' => 'jon.doe@example.com',
+        'phone' => '+1234567890',
+      ],
+      [
+        'name' => 'Rick Morty',
+        'title' => 'Developer',
+        'role' => 'Developer',
+        'email' => 'jon.doe@example.com',
+        'phone' => '+1234567890',
+      ],
+    ];
+    $person = $people[array_rand($people)];
+
+    return [
+      '#theme' => 'person_card',
+      '#image' => $this->getPlaceholderPersonImage(128),
+      '#name' => $person['name'],
+      '#title' => $person['title'],
+      '#role' => $person['role'],
+      '#email' => $person['email'],
+      '#phone' => $person['phone'],
+    ];
+  }
+
+  /**
+   * Get a grid of Person cards.
+   *
+   * @return array
+   *   Render array.
+   */
+  protected function getPersonCardGrid(): array {
+    $people = [
+      [
+        'name' => 'Jon Doe',
+        'title' => 'General Director',
+        'role' => 'Admin',
+        'email' => 'jon.doe@example.com',
+        'phone' => '+1234567890',
+      ],
+      [
+        'name' => 'Smith Allen',
+        'title' => 'General Director',
+        'role' => 'Assistant Manager',
+        'email' => 'jon.doe@example.com',
+        'phone' => '+1234567890',
+      ],
+      [
+        'name' => 'David Bowie',
+        'title' => 'Lead Designer',
+        'role' => 'Admin',
+        'email' => 'jon.doe@example.com',
+        'phone' => '+1234567890',
+      ],
+      [
+        'name' => 'Rick Morty',
+        'title' => 'Developer',
+        'role' => 'Admin',
+        'email' => 'jon.doe@example.com',
+        'phone' => '+1234567890',
+      ],
+      [
+        'name' => 'Jane Smith',
+        'title' => 'General Director',
+        'role' => 'Admin',
+        'email' => 'jon.doe@example.com',
+        'phone' => '+1234567890',
+      ],
+      [
+        'name' => 'Chris Pine',
+        'title' => 'Scrum Master',
+        'role' => 'Editor',
+        'email' => 'jon.doe@example.com',
+        'phone' => '+1234567890',
+      ],
+      [
+        'name' => 'Alex Turner',
+        'title' => 'QA Engineer',
+        'role' => 'Admin',
+        'email' => 'jon.doe@example.com',
+        'phone' => '+1234567890',
+      ],
+      [
+        'name' => 'Sam Carter',
+        'title' => 'Product Owner',
+        'role' => 'Editor',
+        'email' => 'jon.doe@example.com',
+        'phone' => '+1234567890',
+      ],
+      [
+        'name' => 'Pat Lee',
+        'title' => 'Frontend Developer',
+        'role' => 'Admin',
+        'email' => 'jon.doe@example.com',
+        'phone' => '+1234567890',
+      ],
+      [
+        'name' => 'Morgan Yu',
+        'title' => 'Backend Dev',
+        'role' => 'Admin',
+        'email' => 'jon.doe@example.com',
+        'phone' => '+1234567890',
+      ],
+    ];
+
+    $items = [];
+    foreach ($people as $person) {
+      $items[] = [
+        '#theme' => 'person_card',
+        '#image' => $this->getPlaceholderPersonImage(128),
+        '#name' => $person['name'],
+        '#title' => $person['title'],
+        '#role' => $person['role'],
+        '#email' => $person['email'],
+        '#phone' => $person['phone'],
+      ];
+    }
+    return [
+      '#theme' => 'person_card_grid',
+      '#items' => $items,
+    ];
   }
 
 }

--- a/web/themes/custom/server_theme/server_theme.theme
+++ b/web/themes/custom/server_theme/server_theme.theme
@@ -511,6 +511,25 @@ function server_theme_theme() {
     'variables' => [],
   ];
 
+  $info['person_card'] = [
+    'variables' => [
+      'image' => NULL,
+      'name' => NULL,
+      'title' => NULL,
+      'role' => NULL,
+      'email' => NULL,
+      'phone' => NULL,
+    ],
+    'template' => 'server-theme-person-card',
+  ];
+
+  $info['person_card_grid'] = [
+    'variables' => [
+      'items' => [],
+    ],
+    'template' => 'server-theme-cards',
+  ];
+
   return $info;
 }
 
@@ -666,3 +685,4 @@ function server_theme_preprocess_image_style(array &$variables) {
     $variables['image']['#attributes']['loading'] = 'eager';
   }
 }
+

--- a/web/themes/custom/server_theme/templates/server-theme-person-card.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-person-card.html.twig
@@ -1,0 +1,36 @@
+{% import '@server_theme/templates/server-theme-inner-element-layout-base.html.twig' as base %}
+
+<div class="{{ base.getBaseClasses() }} rounded-lg shadow flex flex-col items-center md:max-w-md">
+  <figure class="pt-9 pb-9">
+    <img src="{{ image }}" alt="{{ name }}" class="w-128 h-128 rounded-full object-cover">
+  </figure>
+
+  <div class="text-center px-6 pb-8">
+    <div class="font-bold text-sm mb-2">{{ name }}</div>
+    {% if title %}
+      <div class="description text-sm text-gray-500 mb-1">{{ title }}</div>
+    {% endif %}
+    {% if role %}
+      <div class="text-xs text-green-800 bg-green-100 rounded-[12px] px-2 py-1 inline-block">{{ role }}</div>
+    {% endif %}
+  </div>
+
+  <div class="flex w-full border-t border-gray-200 divide-x divide-gray-200">
+    <div class="flex items-center justify-center flex-1 py-4 space-x-2">
+      <i class="fa fa-envelope text-gray-400"></i>
+      {% if email %}
+        <a href="mailto:{{ email }}" class="text-sm text-gray-600 hover:underline">{{ 'Email'|t }}</a>
+      {% else %}
+        <span class="text-sm text-gray-400">{{ 'Email'|t }}</span>
+      {% endif %}
+    </div>
+    <div class="flex items-center justify-center flex-1 py-4 space-x-2">
+      <i class="fa fa-phone text-gray-400"></i>
+      {% if phone %}
+        <a href="tel:{{ phone }}" class="text-sm text-gray-600 hover:underline">{{ 'Call'|t }}</a>
+      {% else %}
+        <span class="text-sm text-gray-400">{{ 'Call'|t }}</span>
+      {% endif %}
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
This pull request adds the frontend components for the Person card and a responsive grid layout, based on the provided Figma design.

The core of this work was the implementation of the server-theme-person-card.html.twig Twig template, which is styled exclusively with Tailwind CSS. For the grid layout, we've reused the existing grid template from the "People teasers" component, adhering to best practices by avoiding code duplication.

<img width="1350" height="834" alt="Screenshot 2025-08-28 at 10 00 50 AM" src="https://github.com/user-attachments/assets/48c3d4a5-6c0b-4d45-b40f-994280ff8f1a" />

<img width="535" height="818" alt="Screenshot 2025-08-28 at 10 00 35 AM" src="https://github.com/user-attachments/assets/b9bed235-4c4f-46f8-a056-362aeea43ac1" />

<img width="1510" height="833" alt="Screenshot 2025-08-28 at 9 59 57 AM" src="https://github.com/user-attachments/assets/454fc6a9-4a5e-43bd-85e4-ea21bb843741" />

<img width="952" height="841" alt="Screenshot 2025-08-28 at 10 00 14 AM" src="https://github.com/user-attachments/assets/4929af85-e44a-46dd-86de-bfa19f53ed0a" />

<img width="667" height="836" alt="Screenshot 2025-08-28 at 10 00 23 AM" src="https://github.com/user-attachments/assets/f8718707-aab0-4995-a996-ac6dd1da20d0" />

The StyleGuideController was updated to provide the necessary mock data, making the new components available for review at /style-guide.

I've attached some images showing both the single card and the responsive grid to demonstrate the completed work. The components handle different screen sizes and provide a clean, accessible layout.